### PR TITLE
UI simplified for dependencies without version restriction

### DIFF
--- a/Paket.VisualStudio.sln
+++ b/Paket.VisualStudio.sln
@@ -7,6 +7,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3C379C61-EBC9-47FB-945C-61242838D624}"
 	ProjectSection(SolutionItems) = preProject
 		build.fsx = build.fsx
+		paket.dependencies = paket.dependencies
 	EndProjectSection
 EndProject
 Global

--- a/src/Paket.VisualStudio/PaketMetadata.cs
+++ b/src/Paket.VisualStudio/PaketMetadata.cs
@@ -9,6 +9,7 @@ namespace Paket.VisualStudio
         public PaketMetadata(string packageName, string version)
         {
             Id = packageName;
+            if (version == ">= 0") version = "";
             VersionString = version;
         }
 


### PR DESCRIPTION
see: https://github.com/hmemcpy/Paket.VisualStudio/pull/7

I think that '>= 0' is useless info that makes UI more complicated.
Default `no restrictions` case is obvious.

![image](https://cloud.githubusercontent.com/assets/1197905/5395743/32a63578-815d-11e4-99fc-0635536896a5.png)
