### PR TITLE
Add Paket content type

### DIFF
--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketClassifierProvider.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketClassifierProvider.cs
@@ -12,7 +12,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
 {
     [Export(typeof(IVsTextViewCreationListener))]
     [Export(typeof(IClassifierProvider))]
-    [ContentType("Paket")]
+    [ContentType(PaketFileContentType.ContentType)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     internal class PaketClassifierProvider : IClassifierProvider, IVsTextViewCreationListener
     {

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketClassifierProvider.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketClassifierProvider.cs
@@ -12,7 +12,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
 {
     [Export(typeof(IVsTextViewCreationListener))]
     [Export(typeof(IClassifierProvider))]
-    [ContentType("text")]
+    [ContentType("Paket")]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     internal class PaketClassifierProvider : IClassifierProvider, IVsTextViewCreationListener
     {

--- a/src/Paket.VisualStudio/IntelliSense/PaketCompletionController.cs
+++ b/src/Paket.VisualStudio/IntelliSense/PaketCompletionController.cs
@@ -15,7 +15,7 @@ using Paket.VisualStudio.IntelliSense.Classifier;
 namespace Paket.VisualStudio.IntelliSense
 {
     [Export(typeof(IVsTextViewCreationListener))]
-    [ContentType("plaintext")]
+    [ContentType(PaketFileContentType.ContentType)]
     [TextViewRole(PredefinedTextViewRoles.Interactive)]
     internal sealed class PaketCompletionController : IVsTextViewCreationListener
     {

--- a/src/Paket.VisualStudio/IntelliSense/PaketCompletionSourceProvider.cs
+++ b/src/Paket.VisualStudio/IntelliSense/PaketCompletionSourceProvider.cs
@@ -13,7 +13,7 @@ using Paket.VisualStudio.Utils;
 namespace Paket.VisualStudio.IntelliSense
 {
     [Export(typeof(ICompletionSourceProvider))]
-    [ContentType("text")]
+    [ContentType("Paket")]
     [Name("Paket IntelliSense Provider")]
     internal class PaketCompletionSourceProvider : ICompletionSourceProvider
     {

--- a/src/Paket.VisualStudio/IntelliSense/PaketCompletionSourceProvider.cs
+++ b/src/Paket.VisualStudio/IntelliSense/PaketCompletionSourceProvider.cs
@@ -13,7 +13,7 @@ using Paket.VisualStudio.Utils;
 namespace Paket.VisualStudio.IntelliSense
 {
     [Export(typeof(ICompletionSourceProvider))]
-    [ContentType("Paket")]
+    [ContentType(PaketFileContentType.ContentType)]
     [Name("Paket IntelliSense Provider")]
     internal class PaketCompletionSourceProvider : ICompletionSourceProvider
     {

--- a/src/Paket.VisualStudio/Paket.VisualStudio.csproj
+++ b/src/Paket.VisualStudio/Paket.VisualStudio.csproj
@@ -150,6 +150,7 @@
     </Compile>
     <Compile Include="Commands\PackageGui\AddPackageViewModel.cs" />
     <Compile Include="Commands\PackageGui\Converters\LoadingSuccessFailureVisiblityConverter.cs" />
+    <Compile Include="PaketFileContentType.cs" />
     <Compile Include="Utils\DisposableHelpers.cs" />
     <Compile Include="EditorExtensions\CommandTargetBase.cs" />
     <Compile Include="EditorExtensions\CommentCommandTarget.cs" />

--- a/src/Paket.VisualStudio/PaketFileContentType.cs
+++ b/src/Paket.VisualStudio/PaketFileContentType.cs
@@ -12,14 +12,16 @@ namespace Paket.VisualStudio
 {
     internal static class PaketFileContentType
     {
+        public const string ContentType = "Paket";
+
         [Export]
-        [Name("Paket")]
+        [Name(ContentType)]
         [BaseDefinition("text")]
         internal static ContentTypeDefinition PaketContentTypeDefinition;
 
         [Export]
         [FileExtension(".dependencies")]
-        [ContentType("Paket")]
+        [ContentType(ContentType)]
         internal static FileExtensionToContentTypeDefinition PaketFileExtensionDefinition;
     }
 }

--- a/src/Paket.VisualStudio/PaketFileContentType.cs
+++ b/src/Paket.VisualStudio/PaketFileContentType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Paket.VisualStudio
+{
+    internal static class PaketFileContentType
+    {
+        [Export]
+        [Name("Paket")]
+        [BaseDefinition("text")]
+        internal static ContentTypeDefinition PaketContentTypeDefinition;
+
+        [Export]
+        [FileExtension(".dependencies")]
+        [ContentType("Paket")]
+        internal static FileExtensionToContentTypeDefinition PaketFileExtensionDefinition;
+    }
+}


### PR DESCRIPTION
Original issue: https://twitter.com/isaac_abraham/status/613731961136394240
Reference: https://msdn.microsoft.com/en-us/library/ee372313.aspx

It fixes the issue with F# Interactive for me.

However, intellisense stops working even if I use "text" content type on the completion source provider.
/cc @hmemcpy any ideas?

**Update**: My stupid mistake. Intellisense is working again now. The PR is ready.
