### PR TITLE
update to paket core 1.19 

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -25,7 +25,7 @@ NUGET
     Newtonsoft.Json (7.0.1)
     Octokit (0.13.0)
       Microsoft.Net.Http
-    Paket.Core (1.18.2)
+    Paket.Core (1.19.1)
       FSharp.Core
       Newtonsoft.Json
     reactiveui (6.5.0)
@@ -127,5 +127,5 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (98d8f2e57e8f9972703d4237dd62f8e13d6b8d7d)
+    modules/Octokit/Octokit.fsx (4ad6663a0e2179b7f6047612b5bb6357e1543fbf)
       Octokit


### PR DESCRIPTION
this version fixed semver parsing quite a lot, preventing some rather unfortunate accidentally wrong version downloads.
