### PR TITLE
make the restore action unload and reload the solution

### DIFF
--- a/src/Paket.VisualStudio/SolutionExplorer/PaketMenuCommandService.cs
+++ b/src/Paket.VisualStudio/SolutionExplorer/PaketMenuCommandService.cs
@@ -322,7 +322,7 @@ namespace Paket.VisualStudio.SolutionExplorer
 
         private void Restore(object sender, EventArgs e)
         {
-            RunCommand("paket-restore.html", info => // Do we need to unload?
+            RunCommandAndReloadAllProjects("paket-restore.html", info =>
             {
                 Paket.Dependencies.Locate(tracker.GetSelectedFileName())
                     .Restore();


### PR DESCRIPTION
fixes #64 by making the restore also unload.  We've seen VS locking files and it shouldn't hurt to be proactive here.
