### PR TITLE
Replaces VSSDK references with packages

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,6 +6,8 @@ nuget VSSDK.GraphModel.12 copy_local: false
 nuget VSSDK.Language.12 copy_local: false
 nuget VSSDK.Editor.12 copy_local: false
 nuget VSSDK.ComponentModelHost.12 copy_local: false
+nuget VSSDK.Shell.12 copy_local: false
+nuget VSSDK.Shell.Interop.12 copy_local: false
 nuget reactiveui
 nuget reactiveui-events
 

--- a/paket.lock
+++ b/paket.lock
@@ -45,6 +45,8 @@ NUGET
     VSSDK.CoreUtility.12 (12.0.4) - copy_local: false
       VSSDK.CoreUtility (>= 12.0.4 < 13.0.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
+    VSSDK.DTE (7.0.4) - copy_local: false
+      VSSDK.IDE (>= 7.0.4 < 8.0.0)
     VSSDK.Editor (12.0.4) - copy_local: false
       VSSDK.CoreUtility (>= 12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
@@ -63,8 +65,11 @@ NUGET
       VSSDK.GraphModel (>= 12.0.4 < 13.0.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
     VSSDK.IDE (7.0.4) - copy_local: false
+    VSSDK.IDE.10 (10.0.4) - copy_local: false
+    VSSDK.IDE.11 (11.0.4) - copy_local: false
     VSSDK.IDE.12 (12.0.4) - copy_local: false
     VSSDK.IDE.8 (8.0.4) - copy_local: false
+    VSSDK.IDE.9 (9.0.4) - copy_local: false
     VSSDK.Language (12.0.4) - copy_local: false
       VSSDK.CoreUtility (>= 12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
@@ -76,9 +81,61 @@ NUGET
       VSSDK.Text.12 (>= 12.0.4 < 13.0.0)
     VSSDK.OLE.Interop (7.0.4) - copy_local: false
       VSSDK.IDE (>= 7.0.4 < 8.0.0)
+    VSSDK.Shell.12 (12.0.4) - copy_local: false
+      VSSDK.DTE (>= 7.0.4 < 8.0.0)
+      VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Immutable.10 (>= 10.0.4 < 11.0.0)
+      VSSDK.Shell.Immutable.11 (>= 11.0.4 < 12.0.0)
+      VSSDK.Shell.Immutable.12 (>= 12.0.4 < 13.0.0)
+      VSSDK.Shell.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.Shell.Interop.9 (>= 9.0.4 < 10.0.0)
+      VSSDK.TextManager.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Threading.12 (>= 12.0.4 < 13.0.0)
+    VSSDK.Shell.Immutable.10 (10.0.4) - copy_local: false
+      VSSDK.IDE.10 (>= 10.0.4 < 11.0.0)
+    VSSDK.Shell.Immutable.11 (11.0.4) - copy_local: false
+      VSSDK.GraphModel (>= 11.0.4)
+      VSSDK.IDE.11 (>= 11.0.4 < 12.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop (>= 7.0.4 < 8.0.0)
+    VSSDK.Shell.Immutable.12 (12.0.4) - copy_local: false
+      VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
     VSSDK.Shell.Interop (7.0.4) - copy_local: false
       VSSDK.IDE (>= 7.0.4 < 8.0.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.TextManager.Interop (>= 7.0.4 < 8.0.0)
+    VSSDK.Shell.Interop.10 (10.0.4) - copy_local: false
+      VSSDK.IDE.10 (>= 10.0.4 < 11.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.Shell.Interop.9 (>= 9.0.4 < 10.0.0)
+    VSSDK.Shell.Interop.11 (11.0.4) - copy_local: false
+      VSSDK.IDE.11 (>= 11.0.4 < 12.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop.10 (>= 10.0.4 < 11.0.0)
+      VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.Shell.Interop.9 (>= 9.0.4 < 10.0.0)
+    VSSDK.Shell.Interop.12 (12.0.4) - copy_local: false
+      VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop.10 (>= 10.0.4 < 11.0.0)
+      VSSDK.Shell.Interop.11 (>= 11.0.4 < 12.0.0)
+      VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.Shell.Interop.9 (>= 9.0.4 < 10.0.0)
+    VSSDK.Shell.Interop.8 (8.0.4) - copy_local: false
+      VSSDK.IDE.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.TextManager.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.TextManager.Interop.8 (>= 8.0.4 < 9.0.0)
+    VSSDK.Shell.Interop.9 (9.0.4) - copy_local: false
+      VSSDK.IDE.9 (>= 9.0.4 < 10.0.0)
+      VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
+      VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0.0)
     VSSDK.Text (12.0.4) - copy_local: false
       VSSDK.CoreUtility (>= 12.0.4)
@@ -95,6 +152,11 @@ NUGET
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0.0)
       VSSDK.Shell.Interop (>= 7.0.4 < 8.0.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0.0)
+    VSSDK.Threading (12.0.4) - copy_local: false
+      VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
+    VSSDK.Threading.12 (12.0.4) - copy_local: false
+      VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
+      VSSDK.Threading (>= 12.0.4 < 13.0.0)
 
 GROUP Build
 NUGET

--- a/src/Paket.VisualStudio/Paket.VisualStudio.csproj
+++ b/src/Paket.VisualStudio/Paket.VisualStudio.csproj
@@ -55,22 +55,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.12.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -1139,6 +1123,22 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="envdte">
+          <HintPath>..\..\packages\VSSDK.DTE\lib\net20\envdte.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="stdole">
+          <HintPath>..\..\packages\VSSDK.DTE\lib\net20\stdole.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Editor">
@@ -1177,6 +1177,127 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.OLE.Interop">
+          <HintPath>..\..\packages\VSSDK.OLE.Interop\lib\net20\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.12.0">
+          <HintPath>..\..\packages\VSSDK.Shell.12\lib\net45\Microsoft.VisualStudio.Shell.12.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Immutable.10\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Immutable.11\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Immutable.12\lib\net45\Microsoft.VisualStudio.Shell.Immutable.12.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop">
+          <HintPath>..\..\packages\VSSDK.Shell.Interop\lib\net20\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Interop.10\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Interop.11\lib\net20\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Interop.12\lib\net20\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Interop.8\lib\net20\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0">
+          <HintPath>..\..\packages\VSSDK.Shell.Interop.9\lib\net20\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Text.Data">
@@ -1205,8 +1326,30 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.TextManager.Interop">
+          <HintPath>..\..\packages\VSSDK.TextManager.Interop\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0">
           <HintPath>..\..\packages\VSSDK.TextManager.Interop.8\lib\net20\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Threading">
+          <HintPath>..\..\packages\VSSDK.Threading\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Paket.VisualStudio/paket.references
+++ b/src/Paket.VisualStudio/paket.references
@@ -3,6 +3,8 @@ VSSDK.GraphModel.12
 VSSDK.Language.12
 VSSDK.Editor.12
 VSSDK.ComponentModelHost.12
+VSSDK.Shell.12
+VSSDK.Shell.Interop.12
 reactiveui
 reactiveui-events
 MahApps.Metro


### PR DESCRIPTION
This PR makes `Paket.VisualStudio` compilable in machines with VS2015 installed, but no VS2013.
