### PR TITLE
References EnvDTE assemblies from packages

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,6 +2,9 @@ source http://nuget.org/api/v2
 
 nuget MahApps.Metro
 nuget Paket.Core
+nuget VSSDK.DTE.8 copy_local: false
+nuget VSSDK.DTE.9 copy_local: false
+nuget VSSDK.DTE.10 copy_local: false
 nuget VSSDK.GraphModel.12 copy_local: false
 nuget VSSDK.Language.12 copy_local: false
 nuget VSSDK.Editor.12 copy_local: false

--- a/paket.lock
+++ b/paket.lock
@@ -47,6 +47,18 @@ NUGET
       VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)
     VSSDK.DTE (7.0.4) - copy_local: false
       VSSDK.IDE (>= 7.0.4 < 8.0.0)
+    VSSDK.DTE.10 (10.0.4) - copy_local: false
+      VSSDK.DTE (>= 7.0.4 < 8.0.0)
+      VSSDK.DTE.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.DTE.9 (>= 9.0.4 < 10.0.0)
+      VSSDK.IDE.10 (>= 10.0.4 < 11.0.0)
+    VSSDK.DTE.8 (8.0.4) - copy_local: false
+      VSSDK.DTE (>= 7.0.4 < 8.0.0)
+      VSSDK.IDE.8 (>= 8.0.4 < 9.0.0)
+    VSSDK.DTE.9 (9.0.4) - copy_local: false
+      VSSDK.DTE (>= 7.0.4 < 8.0.0)
+      VSSDK.DTE.8 (>= 8.0.4 < 9.0.0)
+      VSSDK.IDE.9 (>= 9.0.4 < 10.0.0)
     VSSDK.Editor (12.0.4) - copy_local: false
       VSSDK.CoreUtility (>= 12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0.0)

--- a/src/Paket.VisualStudio/Paket.VisualStudio.csproj
+++ b/src/Paket.VisualStudio/Paket.VisualStudio.csproj
@@ -72,62 +72,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="EnvDTE">
-      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE100">
-      <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
-      <VersionMajor>10</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE80">
-      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE90">
-      <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
-      <VersionMajor>9</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="Microsoft.VisualStudio.CommandBars">
-      <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="stdole">
-      <Guid>{00020430-0000-0000-C000-000000000046}</Guid>
-      <VersionMajor>2</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="GeneralOptionsControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1025,6 +969,44 @@
         </Reference>
         <Reference Include="stdole">
           <HintPath>..\..\packages\VSSDK.DTE\lib\net20\stdole.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="envdte100">
+          <HintPath>..\..\packages\VSSDK.DTE.10\lib\net20\envdte100.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="envdte80">
+          <HintPath>..\..\packages\VSSDK.DTE.8\lib\net20\envdte80.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="envdte90">
+          <HintPath>..\..\packages\VSSDK.DTE.9\lib\net20\envdte90.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="envdte90a">
+          <HintPath>..\..\packages\VSSDK.DTE.9\lib\net20\envdte90a.dll</HintPath>
           <Private>False</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Paket.VisualStudio/paket.references
+++ b/src/Paket.VisualStudio/paket.references
@@ -1,4 +1,7 @@
 Paket.Core
+VSSDK.DTE.8
+VSSDK.DTE.9
+VSSDK.DTE.10
 VSSDK.GraphModel.12
 VSSDK.Language.12
 VSSDK.Editor.12


### PR DESCRIPTION
This PR fixes the build errors that happens in VS2013.

See https://github.com/fsprojects/Paket.VisualStudio/pull/79#issuecomment-154990540
