### PR TITLE
references is the proper keyword for referencing mode.

### DIFF
--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -14,7 +14,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
         private static readonly HashSet<string> validKeywords = new HashSet<string>
         {
             "source", "nuget", "github", "gist", "http",
-            "content", "reference", "redirects", "group",
+            "content", "references", "redirects", "group",
             "strategy"
         };
 


### PR DESCRIPTION
When adjusting referencing mode, the completion is not the right keyword.
