### PR TITLE
Allow the configuration of API keys

### DIFF
--- a/src/Paket.VisualStudio/APIToken.cs
+++ b/src/Paket.VisualStudio/APIToken.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Paket.VisualStudio
+{
+    [Serializable()]
+    [XmlRoot("configuration")]
+    public class APIToken
+    {
+        [XmlElement("credentials")]
+        public APITokenCredential APITokenCredentials { get; set; }
+    }
+
+    [Serializable()]
+    public class APITokenCredential
+    {
+        public APITokenCredential()
+        {
+            Tokens = new List<Token>();
+        }
+
+        [XmlElement("token")]
+        public List<Token> Tokens { get; set; }
+    }
+
+    [Serializable()]
+    public class Token
+    {
+        [XmlAttribute("source")]
+        public string Source { get; set; }
+
+        [XmlAttribute("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/Paket.VisualStudio/GeneralOptionsControl.Designer.cs
+++ b/src/Paket.VisualStudio/GeneralOptionsControl.Designer.cs
@@ -28,20 +28,29 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.grpPackageRestore = new System.Windows.Forms.GroupBox();
             this.autoRestoreCheckBox = new System.Windows.Forms.CheckBox();
-            this.groupBox1.SuspendLayout();
+            this.grpAPIKeys = new System.Windows.Forms.GroupBox();
+            this.dgvAPIKeys = new System.Windows.Forms.DataGridView();
+            this.colSrcURL = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colKey = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.grpPackageRestore.SuspendLayout();
+            this.grpAPIKeys.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dgvAPIKeys)).BeginInit();
+
             this.SuspendLayout();
             // 
-            // groupBox1
+            // grpPackageRestore
             // 
-            this.groupBox1.Controls.Add(this.autoRestoreCheckBox);
-            this.groupBox1.Location = new System.Drawing.Point(4, 8);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(349, 55);
-            this.groupBox1.TabIndex = 1;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Package Restore";
+            this.grpPackageRestore.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpPackageRestore.Controls.Add(this.autoRestoreCheckBox);
+            this.grpPackageRestore.Location = new System.Drawing.Point(4, 8);
+            this.grpPackageRestore.Name = "grpPackageRestore";
+            this.grpPackageRestore.Size = new System.Drawing.Size(525, 49);
+            this.grpPackageRestore.TabIndex = 1;
+            this.grpPackageRestore.TabStop = false;
+            this.grpPackageRestore.Text = "Package Restore";
             // 
             // autoRestoreCheckBox
             // 
@@ -52,20 +61,68 @@
             this.autoRestoreCheckBox.Text = "Automatically restore packages during build in Visual Studio";
             this.autoRestoreCheckBox.UseVisualStyleBackColor = true;
             // 
+            // grpAPIKeys
+            // 
+            this.grpAPIKeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpAPIKeys.Controls.Add(this.dgvAPIKeys);
+            this.grpAPIKeys.Location = new System.Drawing.Point(6, 67);
+            this.grpAPIKeys.Name = "grpAPIKeys";
+            this.grpAPIKeys.Size = new System.Drawing.Size(523, 147);
+            this.grpAPIKeys.TabIndex = 2;
+            this.grpAPIKeys.TabStop = false;
+            this.grpAPIKeys.Text = "API Keys";
+            // 
+            // dgvAPIKeys
+            // 
+            this.dgvAPIKeys.AllowUserToResizeRows = false;
+            this.dgvAPIKeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dgvAPIKeys.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dgvAPIKeys.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dgvAPIKeys.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.colSrcURL,
+            this.colKey});
+            this.dgvAPIKeys.Location = new System.Drawing.Point(9, 19);
+            this.dgvAPIKeys.MultiSelect = false;
+            this.dgvAPIKeys.Name = "dgvAPIKeys";
+            this.dgvAPIKeys.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dgvAPIKeys.Size = new System.Drawing.Size(508, 118);
+            this.dgvAPIKeys.TabIndex = 3;
+            // 
+            // colSrcURL
+            // 
+            this.colSrcURL.DataPropertyName = "colSrcURL";
+            this.colSrcURL.HeaderText = "URL";
+            this.colSrcURL.Name = "colSrcURL";
+            // 
+            // colKey
+            // 
+            this.colKey.DataPropertyName = "colKey";
+            this.colKey.HeaderText = "Key";
+            this.colKey.Name = "colKey";
+            // 
             // GeneralOptionControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.grpAPIKeys);
+            this.Controls.Add(this.grpPackageRestore);
             this.Name = "GeneralOptionControl";
-            this.Size = new System.Drawing.Size(361, 79);
-            this.groupBox1.ResumeLayout(false);
+            this.Size = new System.Drawing.Size(532, 219);
+            this.grpPackageRestore.ResumeLayout(false);
+            this.grpAPIKeys.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dgvAPIKeys)).EndInit();
             this.ResumeLayout(false);
 
         }
 
         #endregion
-        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.GroupBox grpPackageRestore;
         private System.Windows.Forms.CheckBox autoRestoreCheckBox;
+        private System.Windows.Forms.GroupBox grpAPIKeys;
+        private System.Windows.Forms.DataGridView dgvAPIKeys;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colSrcURL;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colKey;
     }
 }

--- a/src/Paket.VisualStudio/GeneralOptionsControl.cs
+++ b/src/Paket.VisualStudio/GeneralOptionsControl.cs
@@ -1,4 +1,9 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace Paket.VisualStudio
 {
@@ -6,6 +11,8 @@ namespace Paket.VisualStudio
     {
         private readonly PaketSettings settings;
         private bool _initialized;
+
+        public DataGridView APIKeysControl => dgvAPIKeys;
 
         public GeneralOptionControl(PaketSettings settings)
         {
@@ -16,14 +23,105 @@ namespace Paket.VisualStudio
         internal void OnActivated()
         {
             if (!_initialized)
+            {
                 autoRestoreCheckBox.Checked = settings.AutoRestore;
+            }
 
+            dgvAPIKeys.Rows.Clear();
+            var apiTokensConfig = GetAPITokensConfig();
+            foreach (var token in apiTokensConfig.APITokenCredentials.Tokens.Where(token => token.Source != ""))
+            {
+                AddPackageSource(token.Source, token.Value);
+            }
+            
             _initialized = true;
+        }
+
+        private void AddPackageSource(string source, string key)
+        {
+            var row = (DataGridViewRow)dgvAPIKeys.RowTemplate.Clone();
+            row.CreateCells(dgvAPIKeys, source, key);
+            dgvAPIKeys.Rows.Add(row);
+        }
+
+        private static APIToken GetAPITokensConfig()
+        {
+            APIToken apiTokensConfig;
+            var paketConfigPath = Utils.Config.GetPaketConfigPath();
+            File.AppendText(paketConfigPath).Close();
+            CreateRequiredNodes(paketConfigPath);
+            using (var reader = new StreamReader(paketConfigPath))
+            {
+                apiTokensConfig = (APIToken)new XmlSerializer(typeof(APIToken)).Deserialize(reader);
+            }
+            return apiTokensConfig;
         }
 
         internal void OnApply()
         {
+            // Save Auto-Restore Option
             settings.AutoRestore = autoRestoreCheckBox.Checked;
+
+            // Remove current tokens
+            var paketConfigPath = Utils.Config.GetPaketConfigPath();
+            File.AppendText(paketConfigPath).Close();
+
+            var doc = CreateRequiredNodes(paketConfigPath);
+
+            var tokenNodes = doc.DocumentElement?.SelectNodes("/configuration/credentials/token");
+            if (tokenNodes != null)
+            {
+                foreach (XmlNode node in tokenNodes)
+                {
+                    node.ParentNode?.RemoveChild(node);
+                }
+            }
+
+            // Add the new tokens
+            foreach (var row in dgvAPIKeys.Rows.Cast<DataGridViewRow>().Where(
+                row => row.Cells["colSrcURL"].Value?.ToString().Trim() != ""))
+            {
+                var token = doc.CreateElement("token");
+                token.SetAttribute("source", row.Cells["colSrcURL"].Value?.ToString());
+                token.SetAttribute("value", row.Cells["colKey"].Value?.ToString());
+                doc.DocumentElement?.SelectSingleNode("/configuration/credentials")?.AppendChild(token);
+            }
+
+            doc.Save(paketConfigPath);
+        }
+
+        private static XmlDocument CreateRequiredNodes(string paketConfigPath)
+        {
+            var changedFile = false;
+            var doc = new XmlDocument();
+            XmlNode configurationNode;
+
+            try
+            {
+                doc.Load(paketConfigPath);
+            }
+            catch (Exception)
+            {
+                configurationNode = doc.CreateElement("configuration");
+                doc.AppendChild(configurationNode);
+                changedFile = true;
+            }
+
+            var rootNode = doc.DocumentElement;
+
+            configurationNode = rootNode?.SelectSingleNode("/configuration");
+            var credentialNode = rootNode?.SelectSingleNode("/configuration/credentials");
+            if (credentialNode == null)
+            {
+                credentialNode = doc.CreateElement("credentials");
+                configurationNode.AppendChild(credentialNode);
+                changedFile = true;
+            }
+
+            if (changedFile)
+                doc.Save(paketConfigPath);
+
+            return doc;
         }
 
         internal void OnClosed()

--- a/src/Paket.VisualStudio/GeneralOptionsControl.resx
+++ b/src/Paket.VisualStudio/GeneralOptionsControl.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="colSrcURL.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="colKey.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/src/Paket.VisualStudio/Paket.VisualStudio.csproj
+++ b/src/Paket.VisualStudio/Paket.VisualStudio.csproj
@@ -72,6 +72,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="APIToken.cs" />
     <Compile Include="GeneralOptionsControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -102,6 +103,7 @@
     <Compile Include="Restore\PaketRestorer.cs" />
     <Compile Include="Restore\RestoringProject.cs" />
     <Compile Include="Restore\WaitDialogRestorer.cs" />
+    <Compile Include="Utils\Config.cs" />
     <Compile Include="Utils\DisposableHelpers.cs" />
     <Compile Include="EditorExtensions\CommandTargetBase.cs" />
     <Compile Include="EditorExtensions\CommentCommandTarget.cs" />
@@ -158,6 +160,7 @@
     <None Include="app.config" />
     <EmbeddedResource Include="GeneralOptionsControl.resx">
       <DependentUpon>GeneralOptionsControl.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Paket.VisualStudio/PaketOptions.cs
+++ b/src/Paket.VisualStudio/PaketOptions.cs
@@ -12,11 +12,9 @@ namespace Paket.VisualStudio
     public class PaketOptions : DialogPage
     {
         private GeneralOptionControl window;
+        private IServiceProvider ServiceProvider => (IServiceProvider)GetService(typeof(Package));
 
-        protected override IWin32Window Window
-        {
-            get { return General; }
-        }
+        protected override IWin32Window Window => General;
 
         protected override void OnActivate(CancelEventArgs e)
         {
@@ -27,35 +25,43 @@ namespace Paket.VisualStudio
 
         protected override void OnApply(PageApplyEventArgs e)
         {
-            base.OnApply(e);
+            window.APIKeysControl.EndEdit(DataGridViewDataErrorContexts.Commit);
             General.OnApply();
+            base.OnApply(e);
         }
 
         protected override void OnClosed(EventArgs e)
         {
-            base.OnClosed(e);
             General.OnClosed();
+            base.OnClosed(e);
         }
 
         public GeneralOptionControl General
         {
             get {
-                if (window == null)
-                {
-                    window = 
-                        new GeneralOptionControl(
-                            new PaketSettings(
-                                new ShellSettingsManager(ServiceProvider)));
-                    window.Location = new Point(0, 0);
-                }
+                if (window != null)
+                    return window;
+
+                window =
+                    new GeneralOptionControl(
+                        new PaketSettings(
+                            new ShellSettingsManager(ServiceProvider))) {Location = new Point(0, 0)};
 
                 return window;
             }
         }
 
-        private IServiceProvider ServiceProvider
+        protected override void Dispose(bool disposing)
         {
-            get { return (IServiceProvider)GetService(typeof(Package)); }
+            if (disposing)
+            {
+                if (window != null)
+                {
+                    window.Dispose();
+                    window = null;
+                }
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Paket.VisualStudio/Utils/Config.cs
+++ b/src/Paket.VisualStudio/Utils/Config.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.IO;
+
+namespace Paket.VisualStudio.Utils
+{
+    public static class Config
+    {
+        public static string GetPaketConfigPath()
+        {
+            const string PAKET_FOLDER = "paket";
+            const string PAKET_CONFIG_FILE = "paket.config";
+            var roamingFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var paketConfigFolder = Path.Combine(roamingFolder, PAKET_FOLDER);
+            var paketConfigPath = Path.Combine(paketConfigFolder, PAKET_CONFIG_FILE);
+            return paketConfigPath;
+        }
+    }
+}


### PR DESCRIPTION
Our developers are using the UI to manage every aspects of paket, however there was still one part that required us to whip out the console and that was setting up the api key for our private nuget server. So I updated the VS Addin so that we could do so from the UI.

![image](https://cloud.githubusercontent.com/assets/11891420/12891090/6c5c535c-ce54-11e5-8567-be43a81a1c45.png)
I thought that other people could find this useful so if you want you can pull my changes.

It is pretty simple to use, it's just a grid that allows you to add as many server / key combinations as you want and it will save those in the paket.config file (it also reads them from the config).
