### PR TITLE
Call ShowOutdated() with strict=true

### DIFF
--- a/src/Paket.VisualStudio/SolutionExplorer/PaketMenuCommandService.cs
+++ b/src/Paket.VisualStudio/SolutionExplorer/PaketMenuCommandService.cs
@@ -302,7 +302,7 @@ namespace Paket.VisualStudio.SolutionExplorer
             RunCommand("paket-outdated.html", info =>
             {
                 Dependencies.Locate(tracker.GetSelectedFileName())
-                    .ShowOutdated(false, false);
+                    .ShowOutdated(true, false);
             });
         }
 


### PR DESCRIPTION
Strict=true means don't ignore constraints when checking for updates. 

Rationale: The defaults should be the same across tools, and this matches default behavior elsewhere. This matches the default behavior of "packet.exe outdated", and (from briefly looking at the code) the Xamarin Studio plugin too. 
