### PR TITLE
In case Paket Config folder does not exist (which should be pretty ty…

### DIFF
--- a/src/Paket.VisualStudio/GeneralOptionsControl.cs
+++ b/src/Paket.VisualStudio/GeneralOptionsControl.cs
@@ -48,6 +48,8 @@ namespace Paket.VisualStudio
         {
             APIToken apiTokensConfig;
             var paketConfigPath = Utils.Config.GetPaketConfigPath();
+            var paketConfigDirectory = Path.GetDirectoryName(paketConfigPath);
+            Directory.CreateDirectory(paketConfigDirectory);
             File.AppendText(paketConfigPath).Close();
             CreateRequiredNodes(paketConfigPath);
             using (var reader = new StreamReader(paketConfigPath))


### PR DESCRIPTION
…pical) create that folder before trying to create a file with AppendText. AppendText creates the file if it is missing, but it blows if even target directory does not exist.
