### PR TITLE
[WIP] Fix build without VS 2013 SDK installed

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -55,6 +55,8 @@ let release = parseReleaseNotes (IO.File.ReadAllLines "RELEASE_NOTES.md")
 let isAppVeyorBuild = environVar "APPVEYOR" <> null
 let buildVersion = sprintf "%s-a%s" release.NugetVersion (DateTime.UtcNow.ToString "yyMMddHHmm")
 
+let visualStudioVersion = getBuildParamOrDefault "VisualStudioVersion" "12" |> sprintf "%s.0"
+
 let buildDir = "bin"
 let vsixDir = "bin/vsix"
 let tempDir = "temp"
@@ -100,7 +102,7 @@ Target "CleanDocs" (fun _ ->
 Target "Build" (fun _ ->
     // We would like to build only one solution
     !! (solutionFile + ".sln")
-    |> MSBuildReleaseExt  "" ["VisualStudioVersion", "12.0"] "Rebuild"
+    |> MSBuildReleaseExt  "" ["VisualStudioVersion", visualStudioVersion] "Rebuild"
     |> ignore
 )
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,11 +6,11 @@ nuget Paket.Core
 nuget VSSDK.DTE.8 copy_local: false
 nuget VSSDK.DTE.9 copy_local: false
 nuget VSSDK.DTE.10 copy_local: false
-nuget VSSDK.GraphModel.12 copy_local: false
+nuget VSSDK.GraphModel.12
 nuget VSSDK.Language.12 copy_local: false
-nuget VSSDK.Editor.12 copy_local: false
+nuget VSSDK.Editor.12
 nuget VSSDK.ComponentModelHost.12 copy_local: false
-nuget VSSDK.Shell.12 copy_local: false
+nuget VSSDK.Shell.12
 nuget VSSDK.Shell.Interop.12 copy_local: false
 nuget reactiveui
 nuget reactiveui-events

--- a/paket.lock
+++ b/paket.lock
@@ -9,9 +9,17 @@ NUGET
     Newtonsoft.Json (9.0.1)
     Paket.Core (3.28)
       Chessie (>= 0.6)
-      FSharp.Core
-      Mono.Cecil
+      FSharp.Core (>= 0.0.0-prerelease)
+      Mono.Cecil (>= 0.0.0-prerelease)
       Newtonsoft.Json
+      System.Diagnostics.FileVersionInfo (>= 0.0.0-prerelease)
+      System.Diagnostics.Process (>= 0.0.0-prerelease)
+      System.Diagnostics.TraceSource (>= 0.0.0-prerelease)
+      System.Security.Cryptography.Algorithms (>= 0.0.0-prerelease)
+      System.Security.Cryptography.ProtectedData (>= 0.0.0-prerelease)
+      System.Xml.XDocument (>= 0.0.0-prerelease)
+      System.Xml.XPath.XDocument (>= 0.0.0-prerelease)
+      System.Xml.XPath.XmlDocument (>= 0.0.0-prerelease)
     reactiveui (6.5.2)
       reactiveui-core (6.5.2)
     reactiveui-core (6.5.2)
@@ -37,14 +45,35 @@ NUGET
     Rx-Xaml (2.2.5)
       Rx-Main (>= 2.2.5)
     Splat (1.6.2)
+    System.Diagnostics.FileVersionInfo (4.3)
+    System.Diagnostics.Process (4.3)
+    System.Diagnostics.TraceSource (4.3)
+    System.IO (4.3) - framework: >= net463
+    System.Runtime (4.3) - framework: >= net463
+    System.Security.Cryptography.Algorithms (4.3)
+      System.IO (>= 4.3) - framework: >= net463
+      System.Runtime (>= 4.3) - framework: >= net463
+      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= net463
+      System.Security.Cryptography.Primitives (>= 4.3) - framework: net46, net461, >= net463
+    System.Security.Cryptography.Encoding (4.3) - framework: >= net463
+    System.Security.Cryptography.Primitives (4.3) - framework: net46, net461, >= net463
+    System.Security.Cryptography.ProtectedData (4.3)
+    System.Xml.XDocument (4.3)
+    System.Xml.XmlDocument (4.3) - framework: >= net46
+    System.Xml.XPath (4.3)
+    System.Xml.XPath.XDocument (4.3)
+      System.Xml.XPath (>= 4.3) - framework: >= net46
+    System.Xml.XPath.XmlDocument (4.3)
+      System.Xml.XmlDocument (>= 4.3) - framework: >= net46
+      System.Xml.XPath (>= 4.3) - framework: >= net46
     VSSDK.ComponentModelHost (12.0.4) - copy_local: false
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
     VSSDK.ComponentModelHost.12 (12.0.4) - copy_local: false
       VSSDK.ComponentModelHost (>= 12.0.4 < 13.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
-    VSSDK.CoreUtility (12.0.4) - copy_local: false
+    VSSDK.CoreUtility (12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
-    VSSDK.CoreUtility.12 (12.0.4) - copy_local: false
+    VSSDK.CoreUtility.12 (12.0.4)
       VSSDK.CoreUtility (>= 12.0.4 < 13.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
     VSSDK.DTE (7.0.4) - copy_local: false
@@ -61,26 +90,26 @@ NUGET
       VSSDK.DTE (>= 7.0.4 < 8.0)
       VSSDK.DTE.8 (>= 8.0.4 < 9.0)
       VSSDK.IDE.9 (>= 9.0.4 < 10.0)
-    VSSDK.Editor (12.0.4) - copy_local: false
+    VSSDK.Editor (12.0.4)
       VSSDK.CoreUtility (>= 12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
       VSSDK.Text (>= 12.0.4)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0)
       VSSDK.TextManager.Interop.8 (>= 8.0.4 < 9.0)
-    VSSDK.Editor.12 (12.0.4) - copy_local: false
+    VSSDK.Editor.12 (12.0.4)
       VSSDK.CoreUtility.12 (>= 12.0.4 < 13.0)
       VSSDK.Editor (>= 12.0.4 < 13.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
       VSSDK.Text.12 (>= 12.0.4 < 13.0)
-    VSSDK.GraphModel (12.0.4) - copy_local: false
+    VSSDK.GraphModel (12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
-    VSSDK.GraphModel.12 (12.0.4) - copy_local: false
+    VSSDK.GraphModel.12 (12.0.4)
       VSSDK.GraphModel (>= 12.0.4 < 13.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
     VSSDK.IDE (7.0.4) - copy_local: false
     VSSDK.IDE.10 (10.0.4) - copy_local: false
-    VSSDK.IDE.11 (11.0.4) - copy_local: false
+    VSSDK.IDE.11 (11.0.4)
     VSSDK.IDE.12 (12.0.4) - copy_local: false
     VSSDK.IDE.8 (8.0.4) - copy_local: false
     VSSDK.IDE.9 (9.0.4) - copy_local: false
@@ -93,9 +122,9 @@ NUGET
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
       VSSDK.Language (>= 12.0.4 < 13.0)
       VSSDK.Text.12 (>= 12.0.4 < 13.0)
-    VSSDK.OLE.Interop (7.0.4) - copy_local: false
+    VSSDK.OLE.Interop (7.0.4)
       VSSDK.IDE (>= 7.0.4 < 8.0)
-    VSSDK.Shell.12 (12.0.4) - copy_local: false
+    VSSDK.Shell.12 (12.0.4)
       VSSDK.DTE (>= 7.0.4 < 8.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
@@ -107,16 +136,16 @@ NUGET
       VSSDK.Shell.Interop.9 (>= 9.0.4 < 10.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0)
       VSSDK.Threading.12 (>= 12.0.4 < 13.0)
-    VSSDK.Shell.Immutable.10 (10.0.4) - copy_local: false
+    VSSDK.Shell.Immutable.10 (10.0.4)
       VSSDK.IDE.10 (>= 10.0.4 < 11.0)
-    VSSDK.Shell.Immutable.11 (11.0.4) - copy_local: false
+    VSSDK.Shell.Immutable.11 (11.0.4)
       VSSDK.GraphModel (>= 11.0.4)
       VSSDK.IDE.11 (>= 11.0.4 < 12.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
       VSSDK.Shell.Interop (>= 7.0.4 < 8.0)
-    VSSDK.Shell.Immutable.12 (12.0.4) - copy_local: false
+    VSSDK.Shell.Immutable.12 (12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
-    VSSDK.Shell.Interop (7.0.4) - copy_local: false
+    VSSDK.Shell.Interop (7.0.4)
       VSSDK.IDE (>= 7.0.4 < 8.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0)
@@ -140,35 +169,35 @@ NUGET
       VSSDK.Shell.Interop.11 (>= 11.0.4 < 12.0)
       VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0)
       VSSDK.Shell.Interop.9 (>= 9.0.4 < 10.0)
-    VSSDK.Shell.Interop.8 (8.0.4) - copy_local: false
+    VSSDK.Shell.Interop.8 (8.0.4)
       VSSDK.IDE.8 (>= 8.0.4 < 9.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
       VSSDK.Shell.Interop (>= 7.0.4 < 8.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0)
       VSSDK.TextManager.Interop.8 (>= 8.0.4 < 9.0)
-    VSSDK.Shell.Interop.9 (9.0.4) - copy_local: false
+    VSSDK.Shell.Interop.9 (9.0.4)
       VSSDK.IDE.9 (>= 9.0.4 < 10.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
       VSSDK.Shell.Interop.8 (>= 8.0.4 < 9.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0)
-    VSSDK.Text (12.0.4) - copy_local: false
+    VSSDK.Text (12.0.4)
       VSSDK.CoreUtility (>= 12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
-    VSSDK.Text.12 (12.0.4) - copy_local: false
+    VSSDK.Text.12 (12.0.4)
       VSSDK.CoreUtility.12 (>= 12.0.4 < 13.0)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
       VSSDK.Text (>= 12.0.4 < 13.0)
-    VSSDK.TextManager.Interop (7.0.4) - copy_local: false
+    VSSDK.TextManager.Interop (7.0.4)
       VSSDK.IDE (>= 7.0.4 < 8.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
-    VSSDK.TextManager.Interop.8 (8.0.4) - copy_local: false
+    VSSDK.TextManager.Interop.8 (8.0.4)
       VSSDK.IDE.8 (>= 8.0.4 < 9.0)
       VSSDK.OLE.Interop (>= 7.0.4 < 8.0)
       VSSDK.Shell.Interop (>= 7.0.4 < 8.0)
       VSSDK.TextManager.Interop (>= 7.0.4 < 8.0)
-    VSSDK.Threading (12.0.4) - copy_local: false
+    VSSDK.Threading (12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
-    VSSDK.Threading.12 (12.0.4) - copy_local: false
+    VSSDK.Threading.12 (12.0.4)
       VSSDK.IDE.12 (>= 12.0.4 < 13.0)
       VSSDK.Threading (>= 12.0.4 < 13.0)
 

--- a/src/Paket.VisualStudio/Paket.VisualStudio.csproj
+++ b/src/Paket.VisualStudio/Paket.VisualStudio.csproj
@@ -404,6 +404,182 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.FileVersionInfo">
+          <HintPath>..\..\packages\System.Diagnostics.FileVersionInfo\ref\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="mscorlib">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Process">
+          <HintPath>..\..\packages\System.Diagnostics.Process\ref\net46\System.Diagnostics.Process.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Process">
+          <HintPath>..\..\packages\System.Diagnostics.Process\ref\net461\System.Diagnostics.Process.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.TraceSource">
+          <HintPath>..\..\packages\System.Diagnostics.TraceSource\ref\net46\System.Diagnostics.TraceSource.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\ref\net462\System.IO.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Runtime">
+          <HintPath>..\..\packages\System.Runtime\ref\net462\System.Runtime.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\ref\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\ref\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\ref\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Encoding">
+          <HintPath>..\..\packages\System.Security.Cryptography.Encoding\ref\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Primitives">
+          <HintPath>..\..\packages\System.Security.Cryptography.Primitives\ref\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.ProtectedData">
+          <HintPath>..\..\packages\System.Security.Cryptography.ProtectedData\ref\net46\System.Security.Cryptography.ProtectedData.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Security">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Xml.XmlDocument">
+          <HintPath>..\..\packages\System.Xml.XmlDocument\ref\net46\System.Xml.XmlDocument.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Xml.XPath">
+          <HintPath>..\..\packages\System.Xml.XPath\ref\net46\System.Xml.XPath.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Xml.XPath.XDocument">
+          <HintPath>..\..\packages\System.Xml.XPath.XDocument\ref\net46\System.Xml.XPath.XDocument.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="System.Xml.XPath.XmlDocument">
+          <HintPath>..\..\packages\System.Xml.XPath.XmlDocument\ref\netstandard1.3\System.Xml.XPath.XmlDocument.dll</HintPath>
+          <Private>False</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.ComponentModelHost">
@@ -419,7 +595,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.CoreUtility">
           <HintPath>..\..\packages\VSSDK.CoreUtility\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -484,7 +660,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Editor">
           <HintPath>..\..\packages\VSSDK.Editor\lib\net45\Microsoft.VisualStudio.Editor.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -495,7 +671,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.GraphModel">
           <HintPath>..\..\packages\VSSDK.GraphModel\lib\net45\Microsoft.VisualStudio.GraphModel.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -522,7 +698,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.OLE.Interop">
           <HintPath>..\..\packages\VSSDK.OLE.Interop\lib\net20\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -533,7 +709,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.12.0">
           <HintPath>..\..\packages\VSSDK.Shell.12\lib\net45\Microsoft.VisualStudio.Shell.12.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -544,7 +720,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0">
           <HintPath>..\..\packages\VSSDK.Shell.Immutable.10\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -555,7 +731,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0">
           <HintPath>..\..\packages\VSSDK.Shell.Immutable.11\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -566,7 +742,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0">
           <HintPath>..\..\packages\VSSDK.Shell.Immutable.12\lib\net45\Microsoft.VisualStudio.Shell.Immutable.12.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -577,7 +753,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Interop">
           <HintPath>..\..\packages\VSSDK.Shell.Interop\lib\net20\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -621,7 +797,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0">
           <HintPath>..\..\packages\VSSDK.Shell.Interop.8\lib\net20\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -632,7 +808,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0">
           <HintPath>..\..\packages\VSSDK.Shell.Interop.9\lib\net20\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -643,22 +819,22 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Text.Data">
           <HintPath>..\..\packages\VSSDK.Text\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
         <Reference Include="Microsoft.VisualStudio.Text.Logic">
           <HintPath>..\..\packages\VSSDK.Text\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
         <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf">
           <HintPath>..\..\packages\VSSDK.Text\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
         <Reference Include="Microsoft.VisualStudio.Text.UI">
           <HintPath>..\..\packages\VSSDK.Text\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -669,7 +845,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.TextManager.Interop">
           <HintPath>..\..\packages\VSSDK.TextManager.Interop\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -680,7 +856,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0">
           <HintPath>..\..\packages\VSSDK.TextManager.Interop.8\lib\net20\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -691,7 +867,7 @@
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.Threading">
           <HintPath>..\..\packages\VSSDK.Threading\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
-          <Private>False</Private>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>


### PR DESCRIPTION
For the VS version, I have added a build parameter as mentioned in #126.

The ILRepack step needs some VS SDK DLLs, which in practice it apparently got from the installed VS 2013 SDK, so that it fails without that. (And the 2013 SDK can't be installed without VS 2013 itself being installed.)

I could solve that by removing `copy_local: false` from those packages (or in the case of `Microsoft.VisualStudio.CoreUtility` another package that depends on it, because it is not a direct dependency). However, running `paket install` after that added a lot of stuff to the `.csproj` and `paket.lock`, although there were no actual changes to the packages used by the project.

So, yes, this makes the project build without the VS 2013 SDK, but I don't think it *all* of these changes are quite right.