### PR TITLE
VS2017 vsix fix

### DIFF
--- a/src/Paket.VisualStudio/source.extension.vsixmanifest
+++ b/src/Paket.VisualStudio/source.extension.vsixmanifest
@@ -18,7 +18,7 @@
   </Dependencies>
   <Prerequisites>
     <!-- required for VS2017 -->
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26004.1,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.Framework.NDP" Version="[4.5,)" DisplayName="Microsoft .NET Framework" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Fixing .vsixmanifest to correctly build using older msbuild/vs.