### PR TITLE
Keeping minimum dependency on Paket.Core.Dll and using paket.exe instead for operations that modify the solution

### DIFF
--- a/src/Paket.VisualStudio/Commands/AddPackageProcess.cs
+++ b/src/Paket.VisualStudio/Commands/AddPackageProcess.cs
@@ -22,7 +22,8 @@ namespace Paket.VisualStudio.Commands
             catch (Exception)
             {
                 var dir = new System.IO.FileInfo(SolutionExplorerExtensions.GetSolutionFileName()).Directory.FullName;
-                Dependencies.Init(dir);
+                PaketLauncher.LaunchPaket(dir, "init",
+                     (send, args) => PaketOutputPane.OutputPane.OutputStringThreadSafe(args.Data + "\n"));
                 dependenciesFile = Dependencies.Locate(selectedFileName);
             }
 
@@ -46,11 +47,13 @@ namespace Paket.VisualStudio.Commands
                     var guid = Guid.Parse(projectGuid);
                     DteHelper.ExecuteCommand("File.SaveAll");
                     SolutionExplorerExtensions.UnloadProject(guid);
-                    dependenciesFile.AddToProject(FSharpOption<string>.None, result.PackageName, "", false, false, false, false, selectedFileName, true, SemVerUpdateMode.NoRestriction, false);
+                    PaketLauncher.LaunchPaket(SolutionExplorerExtensions.GetSolutionDirectory(), "add " + result.PackageName + " --project " + selectedFileName,
+                        (send, args) => PaketOutputPane.OutputPane.OutputStringThreadSafe(args.Data + "\n"));
                     SolutionExplorerExtensions.ReloadProject(guid);
                 }
                 else
-                    dependenciesFile.Add(FSharpOption<string>.None, result.PackageName, "", false, false, false, false, false, true, SemVerUpdateMode.NoRestriction, false);
+                    PaketLauncher.LaunchPaket(SolutionExplorerExtensions.GetSolutionDirectory(), "add " + result.PackageName,
+                        (send, args) => PaketOutputPane.OutputPane.OutputStringThreadSafe(args.Data + "\n"));
             };
 
             Func<string, IObservable<string>> searchNuGet = 

--- a/src/Paket.VisualStudio/Paket.VisualStudio.csproj
+++ b/src/Paket.VisualStudio/Paket.VisualStudio.csproj
@@ -145,6 +145,7 @@
     <Compile Include="SolutionExplorer\PaketGraphSchema.cs" />
     <Compile Include="SolutionExplorer\PaketMenuCommandService.cs" />
     <Compile Include="Utils\DteHelper.cs" />
+    <Compile Include="Utils\PaketLauncher.cs" />
     <Compile Include="Utils\StringExtensions.cs" />
     <Content Include="..\..\RELEASE_NOTES.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Paket.VisualStudio/Restore/AutoRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/AutoRestorer.cs
@@ -19,11 +19,11 @@ namespace Paket.VisualStudio.Restore
             this.settings = settings;
         }
 
-        public void Restore(Dependencies dependencies, IEnumerable<RestoringProject> projects)
+        public void Restore(IEnumerable<RestoringProject> projects)
         {
             if (!settings.AutoRestore)
                 return;
-            restorer.Restore(dependencies, projects);
+            restorer.Restore(projects);
         }
     }
 }

--- a/src/Paket.VisualStudio/Restore/ErrorReportRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/ErrorReportRestorer.cs
@@ -15,13 +15,13 @@ namespace Paket.VisualStudio.Restore
             this.restorer = restorer;
         }
 
-        public void Restore(Dependencies dependencies, IEnumerable<RestoringProject> projects)
+        public void Restore(IEnumerable<RestoringProject> projects)
         {
             foreach (var project in projects)
             {
                 try
                 {
-                    restorer.Restore(dependencies, new[] { project });
+                    restorer.Restore(new[] { project });
                 }
                 catch (Exception ex)
                 {

--- a/src/Paket.VisualStudio/Restore/IPackageRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/IPackageRestorer.cs
@@ -4,6 +4,6 @@ namespace Paket.VisualStudio.Restore
 {
     public interface IPackageRestorer
     {
-        void Restore(Dependencies dependencies, IEnumerable<RestoringProject> projects);
+        void Restore(IEnumerable<RestoringProject> projects);
     }
 }

--- a/src/Paket.VisualStudio/Restore/OutputPaneRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/OutputPaneRestorer.cs
@@ -15,14 +15,14 @@ namespace Paket.VisualStudio.Restore
             this.restorer = restorer;
         }
 
-        public void Restore(Dependencies dependencies, IEnumerable<RestoringProject> projects)
+        public void Restore(IEnumerable<RestoringProject> projects)
         {
             PaketErrorPane.Clear();
             PaketOutputPane.OutputPane.OutputStringThreadSafe("Restoring packages\r\n");
 
             try
             {
-                restorer.Restore(dependencies, projects);
+                restorer.Restore(projects);
             }
             finally
             {

--- a/src/Paket.VisualStudio/Restore/PackageRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/PackageRestorer.cs
@@ -40,7 +40,7 @@ namespace Paket.VisualStudio.Restore
                 .Select(p => new RestoringProject(p.ProjectName, p.ReferenceFile.Value))
                 .ToList();
 
-            restorer.Restore(dependencies, projects);
+            restorer.Restore(projects);
         }
     }
 }

--- a/src/Paket.VisualStudio/Restore/PaketRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/PaketRestorer.cs
@@ -1,17 +1,19 @@
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.FSharp.Collections;
-using Microsoft.FSharp.Core;
+using Paket.VisualStudio.Utils;
+using Paket.VisualStudio.SolutionExplorer;
 
 namespace Paket.VisualStudio.Restore
 {
     public class PaketRestorer : IPackageRestorer
     {
-        public void Restore(Dependencies dependencies, IEnumerable<RestoringProject> project)
+        public void Restore(IEnumerable<RestoringProject> project)
         {
-            dependencies.Restore(
-                FSharpOption<string>.None,
-                ListModule.OfSeq(project.Select(p => p.ReferenceFile)));
+            string PaketSubCommand = "restore --references-file ";
+            foreach (RestoringProject p in project)
+                PaketSubCommand += p.ReferenceFile + " ";
+
+            PaketLauncher.LaunchPaket(SolutionExplorerExtensions.GetSolutionDirectory(), PaketSubCommand,
+                                    (send, args) => PaketOutputPane.OutputPane.OutputStringThreadSafe(args.Data + "\n"));
         }
     }
 }

--- a/src/Paket.VisualStudio/Restore/WaitDialogRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/WaitDialogRestorer.cs
@@ -21,7 +21,7 @@ namespace Paket.VisualStudio.Restore
             this.waitDialogFactory = waitDialogFactory;
         }
 
-        public void Restore(Dependencies dependencies, IEnumerable<RestoringProject> projects)
+        public void Restore(IEnumerable<RestoringProject> projects)
         {
             var projectsList = projects.ToList();
             IVsThreadedWaitDialog2 waitDialog;
@@ -36,7 +36,7 @@ namespace Paket.VisualStudio.Restore
                     bool canceled;
                     waitDialog.UpdateProgress(string.Format("Restoring packages for {0}", project.ProjectName), null, null, i++, projectsList.Count, false, out canceled);
 
-                    restorer.Restore(dependencies, new[] { project });
+                    restorer.Restore(new[] { project });
                 }
             }
             finally

--- a/src/Paket.VisualStudio/Utils/PaketLauncher.cs
+++ b/src/Paket.VisualStudio/Utils/PaketLauncher.cs
@@ -1,25 +1,57 @@
 ﻿using System.Diagnostics;
+using System.IO;
 
 namespace Paket.VisualStudio.Utils
 {
     public static class PaketLauncher
     {
+        const string PAKET_EXE = ".paket\\paket.exe";
+        const string PAKET_BOOTSTRAPPER_EXE = ".paket\\paket.bootstrapper.exe";
+        const string PAKET_RELEASE_URL = "https://github.com/fsprojects/Paket/releases";
+        const string PAKET_GETTING_STARTED_URL = "https://fsprojects.github.io/Paket/getting-started.html";
+
+        private static int LaunchProcess(string SolutionDirectory, string FileName, string PaketSubCommand, DataReceivedEventHandler PaketDataReceivedHandler)
+        {
+            Process process = new Process();
+            process.StartInfo.FileName = SolutionDirectory + FileName;
+            process.StartInfo.Arguments = PaketSubCommand;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.WorkingDirectory = SolutionDirectory;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.OutputDataReceived += PaketDataReceivedHandler;
+            process.ErrorDataReceived += PaketDataReceivedHandler;
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
+            return process.ExitCode;
+        }
+
         public static void LaunchPaket(string SolutionDirectory, string PaketSubCommand, DataReceivedEventHandler PaketDataReceivedHandler)
         {
-                Process process = new Process();
-                process.StartInfo.FileName = SolutionDirectory + ".paket\\paket.exe";
-                process.StartInfo.Arguments = PaketSubCommand;
-                process.StartInfo.UseShellExecute = false;
-                process.StartInfo.WorkingDirectory = SolutionDirectory;
-                process.StartInfo.RedirectStandardOutput = true;
-                process.StartInfo.RedirectStandardError = true;
-                process.OutputDataReceived += PaketDataReceivedHandler;
-                process.ErrorDataReceived += PaketDataReceivedHandler;
-                process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-                process.WaitForExit();
+            if (!File.Exists(SolutionDirectory + PAKET_EXE))
+            {
+                //If .paket\paket.exe is not found under the solution dir, try launching paket.bootstrapper.exe
+                if (File.Exists(SolutionDirectory + PAKET_BOOTSTRAPPER_EXE))
+                {
+                    int ExitCode = LaunchProcess(SolutionDirectory, PAKET_BOOTSTRAPPER_EXE, "", PaketDataReceivedHandler);
+                    if (ExitCode != 0)
+                        /* If something went wrong with paket.bootstrapper.exe e.g. couldn't download paket.exe due to proxy auth error
+                         * then we should not execute the command that was originally issued for paket.exe.
+                         */
+                        throw new System.Exception("paket.bootstrapper.exe terminated abnormally.");
+                }
+                else
+                    throw new FileNotFoundException(
+                        @"Could not locate .paket\paket.exe and .paket\paket.bootstrapper.exe under the solution " + SolutionDirectory
+                        + "\nTo download the binaries, visit " + PAKET_RELEASE_URL
+                        + "\nTo know more about Paket, visit " + PAKET_GETTING_STARTED_URL + "\n");
+            }
+            /* At this point, all is well .paket\paket.exe exists or .paket\paket.bootstrapper.exe downloaded it successfully.
+             * Now issue the original command to .paket\paket.exe
+             */
+            LaunchProcess(SolutionDirectory, PAKET_EXE, PaketSubCommand, PaketDataReceivedHandler);
         }
     }
-    
 }

--- a/src/Paket.VisualStudio/Utils/PaketLauncher.cs
+++ b/src/Paket.VisualStudio/Utils/PaketLauncher.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+
+namespace Paket.VisualStudio.Utils
+{
+    public static class PaketLauncher
+    {
+        public static void LaunchPaket(string SolutionDirectory, string PaketSubCommand, DataReceivedEventHandler PaketDataReceivedHandler)
+        {
+                Process process = new Process();
+                process.StartInfo.FileName = SolutionDirectory + ".paket\\paket.exe";
+                process.StartInfo.Arguments = PaketSubCommand;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.WorkingDirectory = SolutionDirectory;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.OutputDataReceived += PaketDataReceivedHandler;
+                process.ErrorDataReceived += PaketDataReceivedHandler;
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit();
+        }
+    }
+    
+}


### PR DESCRIPTION
Reference Issue: https://github.com/fsprojects/Paket.VisualStudio/issues/73

Motivation:
- This patch aims at minimizing the dependency of the plugin on Paket.Core.dll and use paket.exe instead for solution modifying operations. Some projects may be using older versions of paket.exe and their paket.lock files may not be compatible with the newer versions which makes it difficult to upgrade the plugin. Also changes to core paket operations trigger a plugin update.

Assumptions:
- .paket\paket.exe or .paket\paket.bootstrapper.exe exists under the SolutionDirectory

Parts that still rely on Paket.Core.dll
- Package search operation still makes use of the DLL because paket find-packages varies across versions. This can be addressed in later patches and dependency from Paket.Core.dll can be completely removed. 