### PR TITLE
Custom exception class for Paket failures so that we catch what is intended to be caught

### DIFF
--- a/src/Paket.VisualStudio/Restore/PaketRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/PaketRestorer.cs
@@ -17,7 +17,7 @@ namespace Paket.VisualStudio.Restore
                 PaketLauncher.LaunchPaket(SolutionExplorerExtensions.GetPaketDirectory(), PaketSubCommand,
                                         (send, args) => PaketOutputPane.OutputPane.OutputStringThreadSafe(args.Data + "\n"));
             }
-            catch (System.Exception ex)
+            catch (PaketRuntimeException ex)
             {
                 /* One of the known reasons for this block to get executed is that if the paket.exe is old then it is likely
                  * that --references-file is not supported and --references-files is supported instead. paket-4.8.4 for instance

--- a/src/Paket.VisualStudio/Utils/PaketLauncher.cs
+++ b/src/Paket.VisualStudio/Utils/PaketLauncher.cs
@@ -1,8 +1,10 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Paket.VisualStudio.Utils
 {
+
     public static class PaketLauncher
     {
         const string PAKET_EXE = ".paket\\paket.exe";
@@ -42,7 +44,7 @@ namespace Paket.VisualStudio.Utils
                         /* If something went wrong with paket.bootstrapper.exe e.g. couldn't download paket.exe due to proxy auth error
                          * then we should not execute the command that was originally issued for paket.exe.
                          */
-                        throw new System.Exception("paket.bootstrapper.exe terminated abnormally.");
+                        throw new PaketRuntimeException("paket.bootstrapper.exe terminated abnormally.");
                 }
                 else
                     throw new FileNotFoundException(
@@ -54,7 +56,25 @@ namespace Paket.VisualStudio.Utils
              * Now issue the original command to .paket\paket.exe
              */
             if (LaunchProcess(SolutionDirectory, PAKET_EXE, PaketSubCommand, PaketDataReceivedHandler) != 0)
-                throw new System.Exception($"{PAKET_EXE} {PaketSubCommand} failed");
+                throw new PaketRuntimeException($"{PAKET_EXE} {PaketSubCommand} failed");
+        }
+    }
+
+    public class PaketRuntimeException : Exception
+    {
+        public PaketRuntimeException()
+            : base()
+        {
+        }
+
+        public PaketRuntimeException(string message)
+            : base(message)
+        {
+        }
+
+        public PaketRuntimeException(string message, Exception inner)
+            : base(message, inner)
+        {
         }
     }
 }


### PR DESCRIPTION
Removing the base type Exception since LaunchProcess may through exceptions and we end up catching it in the restore in a wrong way