### PR TITLE
Support file paths with spaces

### DIFF
--- a/src/Paket.VisualStudio/Restore/PaketRestorer.cs
+++ b/src/Paket.VisualStudio/Restore/PaketRestorer.cs
@@ -10,7 +10,7 @@ namespace Paket.VisualStudio.Restore
         {
             string PaketSubCommand = "restore";
             foreach (RestoringProject p in project)
-                PaketSubCommand += $" --references-file {p.ReferenceFile} ";
+                PaketSubCommand += $" --references-file \"{p.ReferenceFile}\" ";
 
             try
             {


### PR DESCRIPTION
The package restore doesn't support path with spaces, this should fix it.

I couldn't test it, as I wasn't able to compile a vsix which work in VS2017