### PR TITLE
Add more keyword intellisense to paket dependencies

### DIFF
--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -17,7 +17,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
             "content", "references", "redirects", "group",
             "strategy", "framework", "version", "storage", "content",
             "copy_content_to_output_dir", "copy_local", "import_targets",
-            "download_license", "lowest_matching"
+            "download_license", "lowest_matching", "generate_load_scripts"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -15,7 +15,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
         {
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
-            "strategy"
+            "strategy", "framework"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -16,7 +16,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
             "strategy", "framework", "version", "storage", "content",
-            "copy_content_to_output_dir"
+            "copy_content_to_output_dir", "copy_local"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -15,7 +15,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
         {
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
-            "strategy", "framework"
+            "strategy", "framework", "version"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -16,7 +16,8 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
             "strategy", "framework", "version", "storage", "content",
-            "copy_content_to_output_dir", "copy_local", "import_targets"
+            "copy_content_to_output_dir", "copy_local", "import_targets",
+            "download_license"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -15,7 +15,8 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
         {
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
-            "strategy", "framework", "version", "storage", "content"
+            "strategy", "framework", "version", "storage", "content",
+            "copy_content_to_output_dir"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -16,7 +16,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
             "strategy", "framework", "version", "storage", "content",
-            "copy_content_to_output_dir", "copy_local"
+            "copy_content_to_output_dir", "copy_local", "import_targets"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -46,7 +46,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
             {
                 var trimmed = text.TrimStart();
                 var offset = text.Length - trimmed.Length;
-                string[] args = trimmed.Split(' ');
+                string[] args = trimmed.Split(' ', ':');
 
                 if (args.Length >= 2 && ValidKeywords.Contains(args[0].Trim().ToLowerInvariant()))
                 {

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -17,7 +17,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
             "content", "references", "redirects", "group",
             "strategy", "framework", "version", "storage", "content",
             "copy_content_to_output_dir", "copy_local", "import_targets",
-            "download_license"
+            "download_license", "lowest_matching"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -15,7 +15,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
         {
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
-            "strategy", "framework", "version"
+            "strategy", "framework", "version", "storage"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
+++ b/src/Paket.VisualStudio/IntelliSense/Classifier/PaketDependenciesClassifier.cs
@@ -15,7 +15,7 @@ namespace Paket.VisualStudio.IntelliSense.Classifier
         {
             "source", "nuget", "github", "gist", "http",
             "content", "references", "redirects", "group",
-            "strategy", "framework", "version", "storage"
+            "strategy", "framework", "version", "storage", "content"
         };
 
         public static IEnumerable<string> ValidKeywords

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -16,6 +16,7 @@ namespace Paket.VisualStudio.IntelliSense
         ImportTargets,
         DownloadLicense,
         Redirects,
-        LowestMatching
+        LowestMatching,
+        GenerateLoadScripts
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -9,6 +9,7 @@ namespace Paket.VisualStudio.IntelliSense
         Strategy,
         Framework,
         Version,
-        Storage
+        Storage,
+        Content
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -11,6 +11,7 @@ namespace Paket.VisualStudio.IntelliSense
         Version,
         Storage,
         Content,
-        CopyToOutputDirectory
+        CopyToOutputDirectory,
+        CopyLocal
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -7,6 +7,7 @@ namespace Paket.VisualStudio.IntelliSense
         Source,
         Keyword,
         Strategy,
-        Framework
+        Framework,
+        Version
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -13,6 +13,7 @@ namespace Paket.VisualStudio.IntelliSense
         Content,
         CopyToOutputDirectory,
         CopyLocal,
-        ImportTargets
+        ImportTargets,
+        DownloadLicense
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -14,6 +14,7 @@ namespace Paket.VisualStudio.IntelliSense
         CopyToOutputDirectory,
         CopyLocal,
         ImportTargets,
-        DownloadLicense
+        DownloadLicense,
+        Redirects
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -12,6 +12,7 @@ namespace Paket.VisualStudio.IntelliSense
         Storage,
         Content,
         CopyToOutputDirectory,
-        CopyLocal
+        CopyLocal,
+        ImportTargets
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -10,6 +10,7 @@ namespace Paket.VisualStudio.IntelliSense
         Framework,
         Version,
         Storage,
-        Content
+        Content,
+        CopyToOutputDirectory
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -15,6 +15,7 @@ namespace Paket.VisualStudio.IntelliSense
         CopyLocal,
         ImportTargets,
         DownloadLicense,
-        Redirects
+        Redirects,
+        LowestMatching
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -8,6 +8,7 @@ namespace Paket.VisualStudio.IntelliSense
         Keyword,
         Strategy,
         Framework,
-        Version
+        Version,
+        Storage
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -17,6 +17,7 @@ namespace Paket.VisualStudio.IntelliSense
         DownloadLicense,
         Redirects,
         LowestMatching,
-        GenerateLoadScripts
+        GenerateLoadScripts,
+        References
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionContextType.cs
@@ -6,6 +6,7 @@ namespace Paket.VisualStudio.IntelliSense
         InstalledNuGet,
         Source,
         Keyword,
-        Strategy
+        Strategy,
+        Framework
     }
 }

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -35,7 +35,35 @@ namespace Paket.VisualStudio.IntelliSense
             new PaketKeywordCompletionListProvider(ExportProvider.GetExport<IGlyphService>().Value),
             new NuGetNameCompletionListProvider(),
             new SourceCompletionListProvider(),
-            new SimpleOptionCompletionListProvider(CompletionContextType.Strategy, "min", "max")
+            new SimpleOptionCompletionListProvider(CompletionContextType.Strategy, "min", "max"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.Framework,
+                "auto-detect",
+                "net35",
+                "net40",
+                "net45",
+                "net451",
+                "net452",
+                "net46",
+                "net461",
+                "net462",
+                "net47",
+                "netstandard1.0",
+                "netstandard1.1",
+                "netstandard1.2",
+                "netstandard1.3",
+                "netstandard1.4",
+                "netstandard1.5",
+                "netstandard1.6",
+                "netstandard2.0",
+                "netcoreapp1.0",
+                "netcoreapp1.1",
+                "netcoreapp2.0",
+                "uap",
+                "wp7",
+                "wp75",
+                "wp8",
+                "wp81",
+                "wpa81"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -70,7 +98,7 @@ namespace Paket.VisualStudio.IntelliSense
         {
             TextExtent endPosition = navigator.GetExtentOfWord(position - 1);
             TextExtent startPosition = endPosition;
-            
+
             // try to extend the span over .
             while (!String.IsNullOrWhiteSpace(paketDocument.GetCharAt(startPosition.Span.Start.Position - 1)))
             {
@@ -89,6 +117,7 @@ namespace Paket.VisualStudio.IntelliSense
                 pos = startPosition.Span.Start - 1;
 
             TextExtent previous = navigator.GetExtentOfWord(pos);
+
             // try to extend the span over blanks
             while (paketDocument.GetCharAt(previous.Span.Start.Position) == " ")
             {
@@ -105,6 +134,8 @@ namespace Paket.VisualStudio.IntelliSense
                 case "nuget": context.ContextType = CompletionContextType.NuGet; break;
                 case "source": context.ContextType = CompletionContextType.Source; break;
                 case "strategy": context.ContextType = CompletionContextType.Strategy; break;
+                case "framework": context.ContextType = CompletionContextType.Framework; break;
+                case "version": context.ContextType = CompletionContextType.Version; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -68,11 +68,12 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.Storage, "none", "packages", "symlink"),
             new SimpleOptionCompletionListProvider(CompletionContextType.Content, "none", "once"),
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyToOutputDirectory, "always", "never", "preserve_newest"),
-            new SimpleOptionCompletionListProvider(CompletionContextType.CopyLocal, "copy_local", "true", "false"),
-            new SimpleOptionCompletionListProvider(CompletionContextType.ImportTargets, "import_targets", "true", "false"),
-            new SimpleOptionCompletionListProvider(CompletionContextType.DownloadLicense, "download_license", "true", "false"),
-            new SimpleOptionCompletionListProvider(CompletionContextType.LowestMatching, "lowest_matching", "true", "false"),
-            new SimpleOptionCompletionListProvider(CompletionContextType.GenerateLoadScripts, "generate_load_scripts", "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.CopyLocal, "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.ImportTargets, "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.DownloadLicense, "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.Redirects, "off", "on", "force"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.LowestMatching, "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.GenerateLoadScripts, "true", "false"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -64,6 +64,7 @@ namespace Paket.VisualStudio.IntelliSense
                 "wp8",
                 "wp81",
                 "wpa81"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.Version, "<any_paket_version>", "--prefer-nuget")
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -149,6 +149,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "copy_local": context.ContextType = CompletionContextType.CopyLocal; break;
                 case "import_targets": context.ContextType = CompletionContextType.ImportTargets; break;
                 case "download_license": context.ContextType = CompletionContextType.DownloadLicense; break;
+                case "redirects": context.ContextType = CompletionContextType.Redirects; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -64,7 +64,8 @@ namespace Paket.VisualStudio.IntelliSense
                 "wp8",
                 "wp81",
                 "wpa81"),
-            new SimpleOptionCompletionListProvider(CompletionContextType.Version, "<any_paket_version>", "--prefer-nuget")
+            new SimpleOptionCompletionListProvider(CompletionContextType.Version, "<any_paket_version>", "--prefer-nuget"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.Storage, "none", "packages", "symlink"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -137,6 +138,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "strategy": context.ContextType = CompletionContextType.Strategy; break;
                 case "framework": context.ContextType = CompletionContextType.Framework; break;
                 case "version": context.ContextType = CompletionContextType.Version; break;
+                case "storage": context.ContextType = CompletionContextType.Storage; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -72,6 +72,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.ImportTargets, "import_targets", "true", "false"),
             new SimpleOptionCompletionListProvider(CompletionContextType.DownloadLicense, "download_license", "true", "false"),
             new SimpleOptionCompletionListProvider(CompletionContextType.LowestMatching, "lowest_matching", "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.GenerateLoadScripts, "generate_load_scripts", "true", "false"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -152,6 +153,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "download_license": context.ContextType = CompletionContextType.DownloadLicense; break;
                 case "redirects": context.ContextType = CompletionContextType.Redirects; break;
                 case "lowest_matching": context.ContextType = CompletionContextType.LowestMatching; break;
+                case "generate_load_scripts": context.ContextType = CompletionContextType.GenerateLoadScripts; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -74,6 +74,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.Redirects, "off", "on", "force"),
             new SimpleOptionCompletionListProvider(CompletionContextType.LowestMatching, "true", "false"),
             new SimpleOptionCompletionListProvider(CompletionContextType.GenerateLoadScripts, "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.References, "strict"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -155,6 +156,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "redirects": context.ContextType = CompletionContextType.Redirects; break;
                 case "lowest_matching": context.ContextType = CompletionContextType.LowestMatching; break;
                 case "generate_load_scripts": context.ContextType = CompletionContextType.GenerateLoadScripts; break;
+                case "references": context.ContextType = CompletionContextType.References; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -69,6 +69,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.Content, "none", "once"),
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyToOutputDirectory, "always", "never", "preserve_newest"),
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyLocal, "copy_local", "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.ImportTargets, "import_targets", "true", "false"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -145,6 +146,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "content": context.ContextType = CompletionContextType.Content; break;
                 case "copy_content_to_output_dir": context.ContextType = CompletionContextType.CopyToOutputDirectory; break;
                 case "copy_local": context.ContextType = CompletionContextType.CopyLocal; break;
+                case "import_targets": context.ContextType = CompletionContextType.ImportTargets; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -68,6 +68,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.Storage, "none", "packages", "symlink"),
             new SimpleOptionCompletionListProvider(CompletionContextType.Content, "none", "once"),
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyToOutputDirectory, "always", "never", "preserve_newest"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.CopyLocal, "copy_local", "true", "false"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -143,6 +144,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "storage": context.ContextType = CompletionContextType.Storage; break;
                 case "content": context.ContextType = CompletionContextType.Content; break;
                 case "copy_content_to_output_dir": context.ContextType = CompletionContextType.CopyToOutputDirectory; break;
+                case "copy_local": context.ContextType = CompletionContextType.CopyLocal; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -71,6 +71,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyLocal, "copy_local", "true", "false"),
             new SimpleOptionCompletionListProvider(CompletionContextType.ImportTargets, "import_targets", "true", "false"),
             new SimpleOptionCompletionListProvider(CompletionContextType.DownloadLicense, "download_license", "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.LowestMatching, "lowest_matching", "true", "false"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -150,6 +151,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "import_targets": context.ContextType = CompletionContextType.ImportTargets; break;
                 case "download_license": context.ContextType = CompletionContextType.DownloadLicense; break;
                 case "redirects": context.ContextType = CompletionContextType.Redirects; break;
+                case "lowest_matching": context.ContextType = CompletionContextType.LowestMatching; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -70,6 +70,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyToOutputDirectory, "always", "never", "preserve_newest"),
             new SimpleOptionCompletionListProvider(CompletionContextType.CopyLocal, "copy_local", "true", "false"),
             new SimpleOptionCompletionListProvider(CompletionContextType.ImportTargets, "import_targets", "true", "false"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.DownloadLicense, "download_license", "true", "false"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -147,6 +148,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "copy_content_to_output_dir": context.ContextType = CompletionContextType.CopyToOutputDirectory; break;
                 case "copy_local": context.ContextType = CompletionContextType.CopyLocal; break;
                 case "import_targets": context.ContextType = CompletionContextType.ImportTargets; break;
+                case "download_license": context.ContextType = CompletionContextType.DownloadLicense; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -67,6 +67,7 @@ namespace Paket.VisualStudio.IntelliSense
             new SimpleOptionCompletionListProvider(CompletionContextType.Version, "<any_paket_version>", "--prefer-nuget"),
             new SimpleOptionCompletionListProvider(CompletionContextType.Storage, "none", "packages", "symlink"),
             new SimpleOptionCompletionListProvider(CompletionContextType.Content, "none", "once"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.CopyToOutputDirectory, "always", "never", "preserve_newest"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -141,6 +142,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "version": context.ContextType = CompletionContextType.Version; break;
                 case "storage": context.ContextType = CompletionContextType.Storage; break;
                 case "content": context.ContextType = CompletionContextType.Content; break;
+                case "copy_content_to_output_dir": context.ContextType = CompletionContextType.CopyToOutputDirectory; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 

--- a/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
+++ b/src/Paket.VisualStudio/IntelliSense/CompletionEngine.cs
@@ -66,6 +66,7 @@ namespace Paket.VisualStudio.IntelliSense
                 "wpa81"),
             new SimpleOptionCompletionListProvider(CompletionContextType.Version, "<any_paket_version>", "--prefer-nuget"),
             new SimpleOptionCompletionListProvider(CompletionContextType.Storage, "none", "packages", "symlink"),
+            new SimpleOptionCompletionListProvider(CompletionContextType.Content, "none", "once"),
         };
 
         public static IEnumerable<ICompletionListProvider> GetCompletionProviders(IIntellisenseSession session, ITextBuffer textBuffer, SnapshotPoint position, ITextStructureNavigator navigator, out CompletionContext context)
@@ -139,6 +140,7 @@ namespace Paket.VisualStudio.IntelliSense
                 case "framework": context.ContextType = CompletionContextType.Framework; break;
                 case "version": context.ContextType = CompletionContextType.Version; break;
                 case "storage": context.ContextType = CompletionContextType.Storage; break;
+                case "content": context.ContextType = CompletionContextType.Content; break;
                 default: context.ContextType = CompletionContextType.Keyword; break;
             }
 


### PR DESCRIPTION
Update paket.dependencies intellisense with more keywords:
- version
- storage
- content
- copy_content_to_output_dir
- copy_local
- import_targets
- download_license
- redirects
- lowest_matching
- generate_load_scripts